### PR TITLE
Adds a text box to add a custom message to Discord

### DIFF
--- a/PushyFinder/Configuration.cs
+++ b/PushyFinder/Configuration.cs
@@ -15,6 +15,7 @@ public class Configuration : IPluginConfiguration
     public string PushoverUserKey { get; set; } = "";
     public string PushoverDevice { get; set; } = "";
     public string DiscordWebhookToken { get; set; } = "";
+    public string DiscordMessage { get; set; } = "";
     public string NtfyServer { get; set; } = "https://ntfy.sh/";
     public string NtfyTopic { get; set; } = "";
     public string NtfyToken { get; set; } = "";

--- a/PushyFinder/Delivery/DiscordDelivery.cs
+++ b/PushyFinder/Delivery/DiscordDelivery.cs
@@ -9,7 +9,7 @@ namespace PushyFinder.Delivery;
 
 internal class DiscordDelivery : IDelivery
 {
-    public bool IsActive => !Plugin.Configuration.DiscordWebhookToken.IsNullOrWhitespace() && 
+    public bool IsActive => !Plugin.Configuration.DiscordWebhookToken.IsNullOrWhitespace() &&
                             Uri.IsWellFormedUriString(Plugin.Configuration.DiscordWebhookToken, UriKind.Absolute);
 
     public void Deliver(string title, string text)
@@ -25,7 +25,9 @@ internal class DiscordDelivery : IDelivery
             webhook.WithContent(title + "\n" + text);
         else
         {
-            webhook.WithEmbed(new EmbedBuilder()
+            webhook
+                .WithContent(Plugin.Configuration.DiscordMessage)
+                .WithEmbed(new EmbedBuilder()
                               .WithDescription(text)
                               .WithTitle(title)
                               .WithColor(Plugin.Configuration.DiscordEmbedColor)

--- a/PushyFinder/Windows/ConfigWindow.cs
+++ b/PushyFinder/Windows/ConfigWindow.cs
@@ -59,6 +59,10 @@ public class ConfigWindow : Window, IDisposable
     private void DrawDiscordConfig()
     {
         {
+            var cfg = Configuration.DiscordMessage;
+            if (ImGui.InputText("Message", ref cfg, 2048u)) Configuration.DiscordMessage = cfg;
+        }
+        {
             var cfg = Configuration.DiscordWebhookToken;
             if (ImGui.InputText("Webhook URL", ref cfg, 2048u)) Configuration.DiscordWebhookToken = cfg;
         }


### PR DESCRIPTION
Adds a text box to add a custom message (e.g. for pinging specific users <@>, etc.)
<img width="271" alt="image" src="https://github.com/user-attachments/assets/af7822d9-2769-4ae0-b8e9-8e1571f9a35e" />
<img width="374" alt="image" src="https://github.com/user-attachments/assets/db535148-40d3-4e4e-853b-f51e9cb6391e" />
