### PR TITLE
Added Simplepush support

### DIFF
--- a/PushyFinder/Configuration.cs
+++ b/PushyFinder/Configuration.cs
@@ -19,6 +19,9 @@ public class Configuration : IPluginConfiguration
     public string NtfyServer { get; set; } = "https://ntfy.sh/";
     public string NtfyTopic { get; set; } = "";
     public string NtfyToken { get; set; } = "";
+    public string SimplepushKey { get; set; } = "";
+    public string SimplepushTitle { get; set; } = "";
+    public string SimplepushEvent { get; set; } = "";
     public bool EnableForDutyPops { get; set; } = true;
     public bool IgnoreAfkStatus { get; set; } = false;
     public bool DiscordUseEmbed { get; set; } = true;

--- a/PushyFinder/Delivery/MasterDelivery.cs
+++ b/PushyFinder/Delivery/MasterDelivery.cs
@@ -14,7 +14,8 @@ public static class MasterDelivery
     [
         new PushoverDelivery(),
         new NtfyDelivery(),
-        new DiscordDelivery()
+        new DiscordDelivery(),
+        new SimplepushDelivery()
     ];
 
     public static void Deliver(string title, string text)

--- a/PushyFinder/Delivery/SimplepushDelivery.cs
+++ b/PushyFinder/Delivery/SimplepushDelivery.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dalamud.Utility;
+using Flurl.Http;
+
+namespace PushyFinder.Delivery;
+
+public class SimplepushDelivery : IDelivery
+{
+    public static readonly string SimplepushApi = "https://api.simplepush.io/send";
+
+    public bool IsActive => !Plugin.Configuration.SimplepushKey.IsNullOrWhitespace();
+
+    public void Deliver(string title, string text)
+    {
+        Task.Run(() => DeliverAsync(title, text));
+    }
+
+    private static async Task DeliverAsync(string title, string text)
+    {
+        var T = Plugin.Configuration.SimplepushTitle.IsNullOrWhitespace()
+            ? title
+            : Plugin.Configuration.SimplepushTitle;
+        
+        var args = new Dictionary<string, string>
+        {
+            { "key", Plugin.Configuration.SimplepushKey },
+            { "title", title },
+            { "msg", text }
+        };
+        
+        if (!Plugin.Configuration.SimplepushEvent.IsNullOrWhitespace())
+            args.Add("event", Plugin.Configuration.SimplepushEvent);
+
+        try
+        {
+            await SimplepushApi.PostJsonAsync(args);
+            Service.PluginLog.Debug("Sent Simplepush message");
+        }
+        catch (FlurlHttpException e)
+        {
+            Service.PluginLog.Error($"Failed to make Simplepush request: '{e.Message}'");
+            Service.PluginLog.Error($"{e.StackTrace}");
+        }
+    }
+}

--- a/PushyFinder/PushyFinder.json
+++ b/PushyFinder/PushyFinder.json
@@ -2,7 +2,7 @@
   "Author": "Nightshade System",
   "Name": "PushyFinder",
   "Punchline": "Mobile push notifications for the Party Finder.",
-  "Description": "A plugin that uses Pushover (https://pushover.net), Discord, or Ntfy (https://ntfy.sh) to send mobile push notifications when party members join or leave, or when a duty finder queue is initiated.",
+  "Description": "A plugin that uses Pushover (https://pushover.net), Discord, SimplePush (http://simplepush.io), or Ntfy (https://ntfy.sh) to send mobile push notifications when party members join or leave, or when a duty finder queue is initiated.",
   "InternalName": "PushyFinder",
   "ApplicableVersion": "any",
   "Tags": [

--- a/PushyFinder/Windows/ConfigWindow.cs
+++ b/PushyFinder/Windows/ConfigWindow.cs
@@ -36,6 +36,16 @@ public class ConfigWindow : Window, IDisposable
         if (ImGui.InputText("Device name", ref pushoverDevice, 2048)) Configuration.PushoverDevice = pushoverDevice;
     }
 
+    private void DrawSimplepushConfig()
+    {
+        var simplepushKey = Configuration.SimplepushKey ?? "";
+        if (ImGui.InputText("Key", ref simplepushKey, 2048)) Configuration.SimplepushKey = simplepushKey;
+        var simplepushTitle = Configuration.SimplepushTitle ?? "";
+        if (ImGui.InputText("Title (optional)", ref simplepushTitle, 2048)) Configuration.SimplepushTitle = simplepushTitle;
+        var simplepushEvent = Configuration.SimplepushEvent ?? "";
+        if (ImGui.InputText("Event (optional)", ref simplepushEvent, 2048)) Configuration.SimplepushEvent = simplepushEvent;
+    }
+
     private void DrawNtfyConfig()
     {
         var ntfyServer = Configuration.NtfyServer ?? "";
@@ -83,6 +93,10 @@ public class ConfigWindow : Window, IDisposable
                 using (var pushoverTab = ImRaii.TabItem("Pushover"))
                 {
                     if (pushoverTab) DrawPushoverConfig();
+                }
+                using (var simplepushTab = ImRaii.TabItem("Simplepush"))
+                {
+                    if (simplepushTab) DrawSimplepushConfig();
                 }
                 using (var ntfyTab = ImRaii.TabItem("Ntfy"))
                 {


### PR DESCRIPTION
**NOTE: This PR depends on the changes made in PR #23.**

This PR adds Simplepush (https://simplepush.io/) support to PushyFinder. Simplepush only requires a "key" (similar to ntfy, but with no server selection). "Title" and "Event" are optional but "Title" allows you to further customize and "Event" allows you to control vibration patterns and more on mobile.

As mentioned above, PR #23 would have to be merged before this one, but I wanted to go ahead and open it for review. This is my first stacked PR, so please let me know if I did something incorrectly.